### PR TITLE
Changed deviceUids to references, add job.template

### DIFF
--- a/nsx_object_integration/cdo.update.object
+++ b/nsx_object_integration/cdo.update.object
@@ -52,13 +52,13 @@ done < "${IN_FILE_NAME}"
 echo ${OBJECT} > body.json
  
 # save the object
+cat body.json
 curl -s -o output.txt -f -H "Content-Type: application/json" -H "Authorization: bearer ${OAUTH}" -X PUT --data @body.json "${OBJECT_URL}/${OBJECT_UID}" || fail "Could not update \"${OBJECT_NAME}\" object"
 
 # Creating a job to update all affected devices!
 sleep 5
 
-curl -s -f -H "Content-Type: application/json" -H "Authorization: bearer ${OAUTH}" -X GET "${OBJECT_READ_URL}" | jq -r '.deviceUids[]' > device.uids
-
+curl -s -f -H "Content-Type: application/json" -H "Authorization: bearer ${OAUTH}" -X GET "${OBJECT_READ_URL}" | jq -r '.references[].uid' > device.uids
 
 # Initialize the job to no devices
 JOB=$(<job.template)
@@ -70,9 +70,9 @@ do
 done < device.uids
 
 echo ${JOB} > body.json
-echo ${JOB}
 
 JOB_URL="${API_URL}/state-machines/jobs"
+cat body.json
 curl -s -o output.txt -f -H "Content-Type: application/json" -H "Authorization: bearer ${OAUTH}" -X POST --data @body.json "${JOB_URL}" || fail "Could not create job"
 
 

--- a/nsx_object_integration/job.template
+++ b/nsx_object_integration/job.template
@@ -1,0 +1,9 @@
+{
+  "action": "WRITE",
+  "jobContext": null,
+  "objRefs": [],
+  "overallProgress": "PENDING",
+  "schedule": null,
+  "triggerState": "PENDING_ORCHESTRATION"
+}
+


### PR DESCRIPTION
Adjusting to the new way we have references... it used to go to deviceUid field, we changed to add "references" and uid inside. The scope of this exercise is ASA objects, which is enough...

job.template file was missing. I added it. 