### PR TITLE
Feature: Add Overrides To Objects

### DIFF
--- a/cdo.update.overrides/cdo.update.overrides.README
+++ b/cdo.update.overrides/cdo.update.overrides.README
@@ -1,0 +1,19 @@
+Update overrides on a bunch of objects from CSV
+CSV should look like:
+
+Device_name,Object_name,value
+Hollywood,doron,10.10.238.16-10.10.238.17
+Hollywood,15MayStop,10.10.5.31,,,
+jay-ftd-6.5,gateway1542,10.10.5.31
+value can be:
+
+An IP address
+A CIDR
+A range expressed by a dash for exmaple: 10.10.10.10-20.20.20.20
+Usage:
+
+bash cdo.update.overrides input.csv 
+The above will perform a dry run, parse the file, will run API calls to fetch device uid and object uid, compose the PUT body, print everything so we can make sure everything is OK with the input.
+
+bash cdo.update.overrides input.csv doit
+The added doit will make it actually run the PUT commands to make updates to the object and invoke mayhem across the known universe.

--- a/cdo.update.overrides/cdo.update.overrides.csv.original
+++ b/cdo.update.overrides/cdo.update.overrides.csv.original
@@ -1,0 +1,5 @@
+﻿Store,Name,IP
+jay-ftd-6.5,gateway1542,10.10.236.129/25
+Hollywood,doron,10.10.238.16-10.10.238.17
+Hollywood,15MayStop,10.10.5.31,,,
+

--- a/cdo.update.overrides/cdo.update.overrides.sh
+++ b/cdo.update.overrides/cdo.update.overrides.sh
@@ -23,7 +23,6 @@ curl -s -o /dev/null -f -H "Content-Type: application/json" -H "Authorization: b
 
 [ ${2} ] || log "****** DRY RUN **********"
 
-#while IFS=, read -r DEVICE_NAME OBJECT_NAME NEW_SOURCE NEW_DEST alltherest
 while read -r line; do
   # eliminate bad bad bad characters. And adding some padded comas to avoid other issues
   line=${line//[$'\t\r\n ']/},,,,,,
@@ -76,7 +75,6 @@ while read -r line; do
   log "   Existing overrides ${CURRENT_OVERRIDES_EXCLUDING_DEVICE}"
   NEW_OVERRIDE="{ \"reference\": {\"uid\": \"${DEVICE_UID}\", \"@type\": \"ObjectReferenceForAtomicOperations\", \"namespace\": \"targets\", \"type\": \"devices\"}, \"overrideContents\" : [ { \"@type\": \"NetworkContent\", \"sourceElement\": \"${NEW_SOURCE}\", \"destinationElement\": ${NEW_DEST}, \"wildcardMaskElement\": null } ] }"
 
-  # echo "[ { \"@type\": \"NetworkContent\", \"sourceElement\": \"${NEW_VALUE}\", \"destinationElement\": null, \"wildcardMaskElement\": null } ]" > body.json
   echo $CURRENT_OVERRIDES_EXCLUDING_DEVICE | jq --argjson NEW_OVERRIDE "${NEW_OVERRIDE}" '. + [$NEW_OVERRIDE] | { overrides: . }' > body.json
   log "   PUT body: "`cat body.json`
 

--- a/cdo.update.overrides/cdo.update.overrides.sh
+++ b/cdo.update.overrides/cdo.update.overrides.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+#Usage:
+#export OAUTH=my_API_token
+#bash cdo.update.overrides input.csv doit
+
+# log  () { echo $(date +"[%F %R:%S] ") "$@"; }
+log() { echo "$@"; }
+failexit() {
+  log "failure: $@"
+  exit 1
+}
+fail() { log "failure: $@"; }
+
+which -s jq || fail "jq must be installed"
+[ ${OAUTH} ] || fail "You must specify OAuth token in the \$OAUTH system variable"
+[ ${1} ] || fail "${0} <input CSV file name> [doit]"
+[ -f ${1} ] || fail "input file not found: ${1}"
+
+# validate OAUTH token
+API_URL="https://scale.dev.lockhart.io/aegis/rest/v1/services"
+curl -s -o /dev/null -f -H "Content-Type: application/json" -H "Authorization: bearer ${OAUTH}" -X GET "${API_URL}" || failexit "\"${OAUTH}\" is an invalid OAuth token"
+
+[ ${2} ] || log "****** DRY RUN **********"
+
+#while IFS=, read -r DEVICE_NAME OBJECT_NAME NEW_SOURCE NEW_DEST alltherest
+while read -r line; do
+  # eliminate bad bad bad characters. And adding some padded comas to avoid other issues
+  line=${line//[$'\t\r\n ']/},,,,,,
+  IFS=',' read -r -a array <<<"$line"
+  DEVICE_NAME="${array[0]}"
+  OBJECT_NAME="${array[1]}"
+  NEW_VALUE="${array[2]}"
+  NEW_DEST="${array[3]}"
+
+  log "processing line: ${DEVICE_NAME} ${OBJECT_NAME} ${NEW_VALUE}"
+
+  # handle range values. e.g. 10.10.238.16-10.10.238.17
+  NEW_SOURCE=$(echo "${NEW_VALUE}" | cut -d '-' -f 1)
+  NEW_DEST=$(echo "${NEW_VALUE}" | cut -d '-' -f 2)
+  # if no range, then both values are same, have NEW_DEST be null, otherwise quote it, I won't add quotes in the concat
+  if [ "${NEW_DEST}" == "${NEW_SOURCE}" ]; then
+    NEW_DEST=null
+  else
+    NEW_DEST="\"${NEW_DEST}\""
+  fi
+
+  DEVICE_URL="${API_URL}/targets/devices"
+  unset DEVICE_UID
+  DEVICE_UID=$(curl -s -f -H "Content-Type: application/json" -H "Authorization: bearer ${OAUTH}" -X GET "${DEVICE_URL}?q=name:${DEVICE_NAME}" | jq -r '.[0].uid')
+  if [ "x${DEVICE_UID}x" == "xx" ] || [ "x${DEVICE_UID}" == "xnull" ]; then
+    log "   could not find device by name ${DEVICE_NAME}"
+    continue
+  fi
+
+  log "   (with device UID): ${DEVICE_NAME} ${DEVICE_UID} ${OBJECT_NAME} ${NEW_SOURCE} ${NEW_DEST}"
+
+  # find and retrieve the object
+  OBJECT_URL="${API_URL}/targets/objects"
+  OBJECT_SEARCH_URL="${OBJECT_URL}?q=name:${OBJECT_NAME}%20AND%20issueType:SHARED%20AND%20references.uid:${DEVICE_UID}"
+  # curl -s -f -H "Content-Type: application/json" -H "Authorization: bearer ${OAUTH}" -X GET "${OBJECT_SEARCH_URL}" | jq
+  unset OBJECT_UID
+  unset RESPONSE
+  unset CURRENT_OVERRIDES_EXCLUDING_DEVICE
+
+  RESPONSE=$(curl -s -f -H "Content-Type: application/json" -H "Authorization: bearer ${OAUTH}" -X GET "${OBJECT_SEARCH_URL}" | jq -r '.[0]')
+  OBJECT_UID=$(echo ${RESPONSE} | jq -r '.uid')
+
+  if [ "x${OBJECT_UID}x" == "xx" ] || [ "x${OBJECT_UID}" == "xnull" ]; then
+    log "   could not find object by name ${OBJECT_NAME}"
+    continue
+  fi
+
+  log "   (with object UID): ${DEVICE_NAME} ${DEVICE_UID} ${OBJECT_NAME} ${OBJECT_UID} ${NEW_SOURCE} ${NEW_DEST}"
+  CURRENT_OVERRIDES_EXCLUDING_DEVICE=$(echo ${RESPONSE} | jq -r --arg DEVICE_UID "${DEVICE_UID}" '.overrides | map(select(.reference | .uid == $DEVICE_UID | not))')
+  log "   Existing overrides ${CURRENT_OVERRIDES_EXCLUDING_DEVICE}"
+  NEW_OVERRIDE="{ \"reference\": {\"uid\": \"${DEVICE_UID}\", \"@type\": \"ObjectReferenceForAtomicOperations\", \"namespace\": \"targets\", \"type\": \"devices\"}, \"overrideContents\" : [ { \"@type\": \"NetworkContent\", \"sourceElement\": \"${NEW_SOURCE}\", \"destinationElement\": ${NEW_DEST}, \"wildcardMaskElement\": null } ] }"
+
+  # echo "[ { \"@type\": \"NetworkContent\", \"sourceElement\": \"${NEW_VALUE}\", \"destinationElement\": null, \"wildcardMaskElement\": null } ]" > body.json
+  echo $CURRENT_OVERRIDES_EXCLUDING_DEVICE | jq --argjson NEW_OVERRIDE "${NEW_OVERRIDE}" '. + [$NEW_OVERRIDE] | { overrides: . }' > body.json
+  log "   PUT body: "`cat body.json`
+
+  if [ "${2}" == "doit" ]; then
+    log "   executing PUT......."
+    curl -s -o output.txt -f -H "Content-Type: application/json" -H "Authorization: bearer ${OAUTH}" -X PUT --data @body.json "${OBJECT_URL}/${OBJECT_UID}" || fail "update object ${OBJECT_NAME} to ${NEW_SOURCE},${NEW_DEST} on device ${DEVICE_NAME} "
+  fi
+
+done <${1}
+exit


### PR DESCRIPTION
This PR introduces a script cdo.update.overrides.sh to add overrides to a large number of objects across a large number of devices. It uses the same guidelines as the cdo.update.objects script which updates local objects in the non-override world.