### PR TITLE
feat: change sdc selection from index to name selection

### DIFF
--- a/bulk_ios_onboarding/README.md
+++ b/bulk_ios_onboarding/README.md
@@ -11,13 +11,15 @@ To quickly onboard many IOS devices into a CDO environment.
 ```
 docker load < bulk_ios_onboarding_app.tar
 ``` 
-3. Create a new folder with a file titled `devices.csv` with your device onboarding data (see: Creating Device Info File below). Locate the absolute file path of this new folder.
-4. Run the app using this command:
+3. Create a new folder. This folder will contain two files: `devices.csv` and `token.txt`
+4. Populate `devices.csv` file with your device onboarding data (see: Creating Device Info File below). 
+5. Populate the `token.txt` file with your API token from CDO. API token can be found on the Settings page in CDO.
+6. Run the app using this command:
 ```
 docker run -v <absolute_file_path_to_folder_containing_csv_here>:/bulk_ios_onboarding/assets -it bulk_ios_onboarding_app
 ```
-Be sure to provide the absolute path to the folder containing the csv. For instance if you create a file called `devices.csv` that lives in `~/workspace/cdo/devices.csv`, you will want your argument to look like this `-v ~/workspace/cdo/:/bulk_ios_onboarding/assets`. 
-5. Respond to the prompts and supervise the onboarding progress. 
+Be sure to provide the absolute path to the folder containing the csv and txt files. For instance if you create a file called `devices.csv` that lives in `~/workspace/cdo/devices.csv`, you will want your argument to look like this `-v ~/workspace/cdo:/bulk_ios_onboarding/assets`. 
+7. Respond to the prompts and supervise the onboarding progress. 
 
 ## Creating Device Info File
 Create a file that has the following format:

--- a/bulk_ios_onboarding/README.md
+++ b/bulk_ios_onboarding/README.md
@@ -20,7 +20,7 @@ docker run -v <absolute_file_path_to_folder_containing_csv_here>:/bulk_ios_onboa
 ```
 Be sure to provide the absolute path to the folder containing the csv and txt files. For instance if you create a file called `devices.csv` that lives in `~/workspace/cdo/devices.csv`, you will want your argument to look like this `-v ~/workspace/cdo:/bulk_ios_onboarding/assets`. 
 7. Respond to the prompts and supervise the onboarding progress. 
-  a) note, when asked to supply the SDC name, navigate to the /sdc page in the ui. From there you can see the names of all of your Secure Device Connectors. You may pick the SDC that you want to connect to your devices with. It is recommended to use the "On-Prem" sdc.
+  a) note, when asked to supply the SDC ip address, navigate to the /sdc page in the ui. From there you can see all of your Secure Device Connectors. If you select a Secure Device Selector from this list, you will see the ip address in the right hand sidebar. It is recommended to use the "On-Prem" sdc.
 
 ## Creating Device Info File
 Create a file that has the following format:

--- a/bulk_ios_onboarding/README.md
+++ b/bulk_ios_onboarding/README.md
@@ -18,6 +18,7 @@ docker run -v <absolute_file_path_to_folder_containing_csv_here>:/bulk_ios_onboa
 ```
 Be sure to provide the absolute path to the folder containing the csv. For instance if you create a file called `devices.csv` that lives in `~/workspace/cdo/devices.csv`, you will want your argument to look like this `-v ~/workspace/cdo/:/bulk_ios_onboarding/assets`. 
 5. Respond to the prompts and supervise the onboarding progress. 
+  a) note, when asked to supply the SDC name, navigate to the /sdc page in the ui. From there you can see the names of all of your Secure Device Connectors. You may pick the SDC that you want to connect to your devices with. It is recommended to use the "On-Prem" sdc. 
 
 ## Creating Device Info File
 Create a file that has the following format:

--- a/bulk_ios_onboarding/script.py
+++ b/bulk_ios_onboarding/script.py
@@ -21,12 +21,7 @@ if use_default_url == "yes" or use_default_url == "y" or use_default_url == "":
 else:
   cdo_url = input("Enter the url to use for CDO: ")
 
-use_default_sdc = input(colored("Use the first listed SDC to connect to device? [y] ", 'cyan'))
-if use_default_sdc == "yes" or use_default_sdc == "y" or use_default_sdc == "":
-  print("Using the first SDC in list to connect to device.")
-  sdc_index = 0
-else:
-  sdc_index = int(input(colored("Enter the index of the SDC to connect to the device: ", 'cyan')))
+sdc_name = input(colored("Enter the name of the SDC to use: ", 'cyan'))
 
 
 def cdo_query(url, method, body=None):
@@ -109,12 +104,14 @@ def main():
     if not proxy_response:
       print(colored("Did not receive response with SDCs", 'red'))
       quit()
-    elif not proxy_response[sdc_index]:
-      print(colored("Did not find an SDC at given index: " + sdc_index, 'red'))
+    
+    selectedProxy = filter(lambda proxy: (proxy.name == sdc_name), proxy_response)
+    if not selectedProxy:
+      print(colored("Did not find an SDC at with given name: " + sdc_name, 'red'))
       quit()
       
     try: 
-      public_key = proxy_response[sdc_index]['larPublicKey']
+      public_key = selectedProxy['larPublicKey']
       public_key_pem = base64.standard_b64decode(public_key['encodedKey'])
       key_id = public_key['keyId']
     except:

--- a/bulk_ios_onboarding/script.py
+++ b/bulk_ios_onboarding/script.py
@@ -12,8 +12,6 @@ from termcolor import colored
 
 DEVICES_ENDPOINT = 'services/targets/devices/'
 
-token = input(colored("Enter your access token for CDO: ", 'cyan'))
-
 use_default_url = input(colored("Use default https://defenseorchestrator.com url? [y] ", 'cyan'))
 if use_default_url == "yes" or use_default_url == "y" or use_default_url == "":
   print("Using default url.")
@@ -28,6 +26,9 @@ if use_default_sdc == "yes" or use_default_sdc == "y" or use_default_sdc == "":
 else:
   sdc_index = int(input(colored("Enter the index of the SDC to connect to the device: ", 'cyan')))
 
+print(colored("Reading CDO token...", 'yellow'))
+token = open('assets/token.txt', 'r').read().strip()
+print(colored("Read token!", 'green'))
 
 def cdo_query(url, method, body=None):
     query_url = cdo_url + '/aegis/rest/v1/' + url
@@ -103,7 +104,7 @@ def main():
       reader = csv.reader(f)
       devices_list = list(reader)
 
-    print(colored("Successfully read devices data!", "red"))
+    print(colored("Successfully read devices data!", "green"))
 
     proxy_response = cdo_query('services/targets/proxies', 'GET')
     if not proxy_response:

--- a/bulk_ios_onboarding/script.py
+++ b/bulk_ios_onboarding/script.py
@@ -19,7 +19,7 @@ if use_default_url == "yes" or use_default_url == "y" or use_default_url == "":
 else:
   cdo_url = input("Enter the url to use for CDO: ")
 
-sdc_name = input(colored("Enter the name of the SDC to use: ", 'cyan'))
+sdc_ip = input(colored("Enter the ip of the SDC to use: ", 'cyan'))
 
 print(colored("Reading CDO token...", 'yellow'))
 token = open('assets/token.txt', 'r').read().strip()
@@ -106,9 +106,9 @@ def main():
       print(colored("Did not receive response with SDCs", 'red'))
       quit()
     
-    selectedProxy = next(filter(lambda proxy: (proxy['name'] == sdc_name), proxy_response))
+    selectedProxy = next(filter(lambda proxy: (proxy['ipAddress'] == sdc_ip), proxy_response))
     if not selectedProxy:
-      print(colored("Did not find an SDC at with given name: " + sdc_name, 'red'))
+      print(colored("Did not find an SDC at with given ip: " + sdc_ip, 'red'))
       quit()
       
     try: 

--- a/bulk_ios_onboarding/script.py
+++ b/bulk_ios_onboarding/script.py
@@ -106,7 +106,7 @@ def main():
       print(colored("Did not receive response with SDCs", 'red'))
       quit()
     
-    selectedProxy = filter(lambda proxy: (proxy.name == sdc_name), proxy_response)
+    selectedProxy = next(filter(lambda proxy: (proxy['name'] == sdc_name), proxy_response))
     if not selectedProxy:
       print(colored("Did not find an SDC at with given name: " + sdc_name, 'red'))
       quit()


### PR DESCRIPTION
Allow the user to select the sdc that they onboard IOS devices with by name instead of index. Index proved to be unreliable because the ordering changed based on last heartbeat. 